### PR TITLE
Add custom entry class option

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The plugin reads your Daily Note settings to know your date format, your daily n
 - **Words per Dot [default: 250]**: Starting in version 1.3, dots reflect the word count of your files. By default, each dot represents 250 words, you can change that value to whatever you want. Set this to `0` to disable the word count entirely. **Note:** There is a max of 5 dots so that the view doesn't get too big!
 - **Confirm before creating new note [default: on]**: If you don't like that a modal prompts you before creating a new daily note, you can turn it off.
 - **Show Week Number [default: off]**: Enable this to add a new column to the calendar view showing the [Week Number](https://en.wikipedia.org/wiki/Week#Week_numbering). Clicking on these cells will open your **weekly note**.
+- **Entry CSS class [default: empty]**: Add this class to each calendar entry (days and week numbers) for easier custom styling.
 
 ## Customization
 
@@ -59,6 +60,16 @@ In addition to the CSS Variables, there are some classes you can override for fu
 ```
 
 > **Note:** It's especially important when overriding the classes to prefix them with `#calendar-container` to avoid any unexpected changes within Obsidian!
+
+### Custom entry class
+
+You can specify a custom class in the plugin settings. The class will be added to every day cell and week number entry, making it easy to style them all at once.
+
+```css
+#calendar-container .my-calendar-entry {
+  /* your styles */
+}
+```
 
 ### Caution to Theme Creators
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -17,6 +17,8 @@ export interface ISettings {
   weeklyNoteTemplate: string;
   weeklyNoteFolder: string;
 
+  entryCardClass: string;
+
   localeOverride: ILocaleOverride;
 }
 
@@ -40,6 +42,8 @@ export const defaultSettings = Object.freeze({
   weeklyNoteFormat: "",
   weeklyNoteTemplate: "",
   weeklyNoteFolder: "",
+
+  entryCardClass: "",
 
   localeOverride: "system-default",
 });
@@ -103,6 +107,7 @@ export class CalendarSettingsTab extends PluginSettingTab {
       text: "Advanced Settings",
     });
     this.addLocaleOverrideSetting();
+    this.addEntryCardClassSetting();
   }
 
   addDotThresholdSetting(): void {
@@ -233,6 +238,20 @@ export class CalendarSettingsTab extends PluginSettingTab {
           this.plugin.writeOptions(() => ({
             localeOverride: value as ILocaleOverride,
           }));
+        });
+      });
+  }
+
+  addEntryCardClassSetting(): void {
+    new Setting(this.containerEl)
+      .setName("Entry CSS class")
+      .setDesc(
+        "Class name to add to each calendar entry for custom styling"
+      )
+      .addText((textfield) => {
+        textfield.setValue(this.plugin.options.entryCardClass);
+        textfield.onChange(async (value) => {
+          this.plugin.writeOptions(() => ({ entryCardClass: value }));
         });
       });
   }

--- a/src/ui/Calendar.svelte
+++ b/src/ui/Calendar.svelte
@@ -18,12 +18,30 @@
 
   export let displayedMonth: Moment = today;
   export let sources: ICalendarSource[];
+  export let entryCardClass: string = "";
   export let onHoverDay: (date: Moment, targetEl: EventTarget) => boolean;
   export let onHoverWeek: (date: Moment, targetEl: EventTarget) => boolean;
   export let onClickDay: (date: Moment, isMetaPressed: boolean) => boolean;
   export let onClickWeek: (date: Moment, isMetaPressed: boolean) => boolean;
   export let onContextMenuDay: (date: Moment, event: MouseEvent) => boolean;
   export let onContextMenuWeek: (date: Moment, event: MouseEvent) => boolean;
+
+  let computedSources: ICalendarSource[];
+  $: {
+    if (entryCardClass) {
+      const classSource: ICalendarSource = {
+        async getDailyMetadata() {
+          return { classes: [entryCardClass] };
+        },
+        async getWeeklyMetadata() {
+          return { classes: [entryCardClass] };
+        },
+      };
+      computedSources = [...sources, classSource];
+    } else {
+      computedSources = sources;
+    }
+  }
 
   export function tick() {
     today = window.moment();
@@ -53,8 +71,9 @@
   });
 </script>
 
+
 <CalendarBase
-  {sources}
+  sources={computedSources}
   {today}
   {onHoverDay}
   {onHoverWeek}

--- a/src/view.ts
+++ b/src/view.ts
@@ -23,6 +23,7 @@ import {
   tasksSource,
   wordCountSource,
 } from "./ui/sources";
+import type { ICalendarSource } from "obsidian-calendar-ui";
 
 export default class CalendarView extends ItemView {
   private calendar: Calendar;
@@ -65,6 +66,7 @@ export default class CalendarView extends ItemView {
       // Refresh the calendar if settings change
       if (this.calendar) {
         this.calendar.tick();
+        this.calendar.$set({ entryCardClass: val.entryCardClass });
       }
     });
   }
@@ -97,6 +99,17 @@ export default class CalendarView extends ItemView {
       wordCountSource,
       tasksSource,
     ];
+    if (this.settings.entryCardClass) {
+      const cls = this.settings.entryCardClass;
+      sources.push({
+        async getDailyMetadata() {
+          return { classes: [cls] };
+        },
+        async getWeeklyMetadata() {
+          return { classes: [cls] };
+        },
+      } as ICalendarSource);
+    }
     this.app.workspace.trigger(TRIGGER_ON_OPEN, sources);
 
     this.calendar = new Calendar({
@@ -110,6 +123,7 @@ export default class CalendarView extends ItemView {
         onContextMenuDay: this.onContextMenuDay,
         onContextMenuWeek: this.onContextMenuWeek,
         sources,
+        entryCardClass: this.settings.entryCardClass,
       },
     });
   }


### PR DESCRIPTION
## Summary
- allow configuring a CSS class for calendar entries
- show new setting in Calendar options
- forward the class to the calendar view
- document the new option and styling hook

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ebc7606f08325a86028bffb1fc390